### PR TITLE
Updates rxjs as per Angular 5.0

### DIFF
--- a/src/odometer/odometer.component.ts
+++ b/src/odometer/odometer.component.ts
@@ -6,7 +6,8 @@
 
 import * as _ from 'lodash';
 import { Component, ViewEncapsulation, Input, OnInit, OnDestroy, OnChanges, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
-import { Subscription, Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 import { OdometerModel } from './odometer.model';
 import { Ng2OdometerConfig, Ng2OdometerConfigModel } from './odometer.config';
 import {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Angular 5.0 uses RxJS 5.5, which requires import of Observable, Subscription separately from respective files .




* **What is the current behavior?** (You can also link to an open issue here)
Currently Observable, Subscription imported from 'rxjs', which fails to build in Angular 5.0


* **What is the new behavior (if this is a feature change)?**
There is no change in functionality, its only update to importing.


* **Other information**:
